### PR TITLE
fix nonexistent argument "shellcustom" error

### DIFF
--- a/MsfMania.py
+++ b/MsfMania.py
@@ -56,7 +56,7 @@ def check_payload_requirements():
                 core.error_payload_lport()
         else:
             core.error_payload_lhost()
-    elif args.shellcustom:
+    elif args.msfcustom:
         pass
     else:
         core.error_payload_required()


### PR DESCRIPTION
replaced shellcustom with msfcustom in order to get rid of this error

```
λ py MsfMania.py -a x64 -o test -it local
                                                                                            
                ███╗   ███╗███████╗███████╗███╗   ███╗ █████╗ ███╗   ██╗██╗ █████╗ 
                ████╗ ████║██╔════╝██╔════╝████╗ ████║██╔══██╗████╗  ██║██║██╔══██╗
                ██╔████╔██║███████╗█████╗  ██╔████╔██║███████║██╔██╗ ██║██║███████║
                ██║╚██╔╝██║╚════██║██╔══╝  ██║╚██╔╝██║██╔══██║██║╚██╗██║██║██╔══██║
                ██║ ╚═╝ ██║███████║██║     ██║ ╚═╝ ██║██║  ██║██║ ╚████║██║██║  ██║
                ╚═╝     ╚═╝╚══════╝╚═╝     ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝                                                                                                                                                                                                                   
             Version : 2.4   -   Author : Killian CASAROTTO   -  Updated : 08/03/2021           
    
Traceback (most recent call last):
  File "/home/bruh/Git/MsfMania/MsfMania.py", line 235, in <module>
    check_payload_requirements()
  File "/home/bruh/Git/MsfMania/MsfMania.py", line 59, in check_payload_requirements
    elif args.shellcustom:
AttributeError: 'Namespace' object has no attribute 'shellcustom'
```